### PR TITLE
Fix error with cypress 3.7

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ Cypress.Commands.add('mhGetAllMails', () => {
       method: 'GET',
       url: mhApiUrl('/v2/messages?limit=9999'),
     })
-    .then((response) => JSON.parse(response.body))
+    .then((response) => response.body)
     .then((parsed) => parsed.items);
 });
 


### PR DESCRIPTION
Cypress 3.7 already decodes the json so the parsing fails if it is called for the json object.